### PR TITLE
Require jvm-application-package in build plan

### DIFF
--- a/distzip/detect.go
+++ b/distzip/detect.go
@@ -23,6 +23,12 @@ import (
 	"github.com/paketo-buildpacks/libpak"
 )
 
+const (
+	PlanEntryJVMApplication        = "jvm-application"
+	PlanEntryJVMApplicationPackage = "jvm-application-package"
+	PlanEntryJRE                   = "jre"
+)
+
 type Detect struct{}
 
 func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
@@ -30,9 +36,13 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 		Pass: true,
 		Plans: []libcnb.BuildPlan{
 			{
+				Provides: []libcnb.BuildPlanProvide{
+					{Name: PlanEntryJVMApplication},
+				},
 				Requires: []libcnb.BuildPlanRequire{
-					{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-					{Name: "jvm-application"},
+					{Name: PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+					{Name: PlanEntryJVMApplicationPackage},
+					{Name: PlanEntryJVMApplication},
 				},
 			},
 		},
@@ -48,7 +58,7 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 		ConfigurationResolver: cr,
 	}
 	if _, ok, _ := sr.Resolve(); ok {
-		result.Plans[0].Provides = append(result.Plans[0].Provides, libcnb.BuildPlanProvide{Name: "jvm-application"})
+		result.Plans[0].Provides = append(result.Plans[0].Provides, libcnb.BuildPlanProvide{Name: PlanEntryJVMApplicationPackage})
 	}
 
 	return result, nil

--- a/distzip/detect_test.go
+++ b/distzip/detect_test.go
@@ -57,55 +57,75 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(ctx.Application.Path)).To(Succeed())
 	})
 
-	it("passes without application script", func() {
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-						{Name: "jvm-application"},
+	context("application script not found", func() {
+		it("requires jvm-application-package", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "jvm-application"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
+							{Name: "jvm-application-package"},
+							{Name: "jvm-application"},
+						},
 					},
 				},
-			},
-		}))
+			}))
+		})
 	})
 
-	it("passes with multiple application scripts", func() {
-		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "app", "bin"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "app", "bin", "script-1"), []byte{}, 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "app", "bin", "script-2"), []byte{}, 0755)).To(Succeed())
+	context("multiple application scripts", func() {
+		it.Before(func() {
+			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "app", "bin"), 0755)).To(Succeed())
+			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "app", "bin", "script-1"), []byte{}, 0755)).To(Succeed())
+			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "app", "bin", "script-2"), []byte{}, 0755)).To(Succeed())
+		})
 
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-						{Name: "jvm-application"},
+		it("requires jvm-application-package", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "jvm-application"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
+							{Name: "jvm-application-package"},
+							{Name: "jvm-application"},
+						},
 					},
 				},
-			},
-		}))
+			}))
+		})
 	})
 
-	it("passes and provices with single application script", func() {
-		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "app", "bin"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "app", "bin", "script"), []byte{}, 0755)).To(Succeed())
+	context("single application script", func() {
+		it.Before(func() {
+			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "app", "bin"), 0755)).To(Succeed())
+			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "app", "bin", "script"), []byte{}, 0755)).To(Succeed())
+		})
 
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "jvm-application"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-						{Name: "jvm-application"},
+		it("requires and provides jvm-application-package", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "jvm-application"},
+							{Name: "jvm-application-package"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
+							{Name: "jvm-application-package"},
+							{Name: "jvm-application"},
+						},
 					},
 				},
-			},
-		}))
+			}))
+		})
 	})
 }


### PR DESCRIPTION
Previously we used the jvm-application build plan entry to represent two concepts

1. package containing application bytecode
1. process types and configuration that will launch JVM application in the final image

This PR uses a new entry called `jvm-application-package` to represent application bytecode. Creating this distinction makes the role a given buildpack plays clearer and solves a practical problem. Previously, when building from source code the `jvm-application` plan entry was being met by a build system buildpack (e.g. `paketo-buildpacks/maven`) and therefore not passed to buildpacks that contribute start commands (like `paketo-buildpacks/dist-zip`). Therefore, if a downstream buildpack wanted to add metadata to the jvm-application plan entry, intended to modify the behavior of a JVM application buildpack, that metadata would not be present if the image was built from source.

This depends on coordinated changes in the build system buildpacks:
* https://github.com/paketo-buildpacks/maven/pull/48
* https://github.com/paketo-buildpacks/gradle/pull/57
* https://github.com/paketo-buildpacks/leiningen/pull/43
* https://github.com/paketo-buildpacks/sbt/pull/54