### PR TITLE
Buildpack metadata updates

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api = "0.5"
+api = "0.6"
 
 [buildpack]
 id       = "paketo-buildpacks/dist-zip"
 name     = "Paketo DistZip Buildpack"
 version  = "{{.version}}"
 homepage = "https://github.com/paketo-buildpacks/dist-zip"
+description = "A Cloud Native Buildpack that contributes a Process Type for DistZip-style applications"
+keywords    = ["java", "dist-zip"]
+
+[[buildpack.licenses]]
+type = "Apache-2.0"
+uri  = "https://github.com/paketo-buildpacks/dist-zip/blob/main/LICENSE"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"

--- a/distzip/build.go
+++ b/distzip/build.go
@@ -62,7 +62,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	result.Processes = append(result.Processes,
 		libcnb.Process{Type: "dist-zip", Command: s},
 		libcnb.Process{Type: "task", Command: s},
-		libcnb.Process{Type: "web", Command: s},
+		libcnb.Process{Type: "web", Command: s, Default: true},
 	)
 
 	return result, nil

--- a/distzip/build_test.go
+++ b/distzip/build_test.go
@@ -74,7 +74,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(result.Processes).To(ContainElements(
 				libcnb.Process{Type: "dist-zip", Command: filepath.Join(ctx.Application.Path, "app", "bin", "test-script")},
 				libcnb.Process{Type: "task", Command: filepath.Join(ctx.Application.Path, "app", "bin", "test-script")},
-				libcnb.Process{Type: "web", Command: filepath.Join(ctx.Application.Path, "app", "bin", "test-script")},
+				libcnb.Process{Type: "web", Command: filepath.Join(ctx.Application.Path, "app", "bin", "test-script"), Default: true},
 			))
 		})
 	})

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,8 +4,13 @@ set -euo pipefail
 
 GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/paketo-buildpacks/dist-zip/cmd/main
 
-strip bin/main
-upx -q -9 bin/main
+if [ "${STRIP:-false}" != "false" ]; then
+  strip bin/main
+fi
+
+if [ "${COMPRESS:-false}" != "false" ]; then
+  upx -q -9 bin/main
+fi
 
 ln -fs main bin/build
 ln -fs main bin/detect


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Bump the lifecycle to 0.6, add a description, keywords and license metadata and make running 'upx' optional, default off in build script, and sets web as the default process type

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
