### PR TITLE
Make script resolution more strict

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -26,8 +26,10 @@ import (
 )
 
 func main() {
+	logger := bard.NewLogger(os.Stdout)
+
 	libpak.Main(
-		distzip.Detect{},
-		distzip.Build{Logger: bard.NewLogger(os.Stdout)},
+		distzip.Detect{Logger: logger},
+		distzip.Build{Logger: logger},
 	)
 }

--- a/distzip/build.go
+++ b/distzip/build.go
@@ -43,6 +43,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	sr := ScriptResolver{
 		ApplicationPath:       context.Application.Path,
 		ConfigurationResolver: cr,
+		Logger:                b.Logger,
 	}
 	s, ok, err := sr.Resolve()
 	if err != nil {

--- a/distzip/script_resolver.go
+++ b/distzip/script_resolver.go
@@ -23,11 +23,13 @@ import (
 	"strings"
 
 	"github.com/paketo-buildpacks/libpak"
+	"github.com/paketo-buildpacks/libpak/bard"
 )
 
 type ScriptResolver struct {
 	ApplicationPath       string
 	ConfigurationResolver libpak.ConfigurationResolver
+	Logger                bard.Logger
 }
 
 func (s *ScriptResolver) Resolve() (string, bool, error) {
@@ -67,6 +69,8 @@ func (s *ScriptResolver) Resolve() (string, bool, error) {
 		return candidates[0], true, nil
 	default:
 		sort.Strings(candidates)
-		return "", false, fmt.Errorf("unable to find application script in %s, candidates: %s", pattern, candidates)
+		s.Logger.Debugf("too many application scripts in %s, candidates: %s", pattern, candidates)
+		s.Logger.Debug("set a more strict `$BP_APPLICATION_SCRIPT` pattern that only matches a single script")
+		return "", false, nil
 	}
 }


### PR DESCRIPTION
## Summary

Presently, script resolution looks at the default pattern of `*/bin/*`. This matches any zip with a bin directory and one or more files in it. This can incorrectly flag something like a Liberty packaged server as a dist-zip archive.

This change makes the script resolver more strict. It will only pass if there is a single script matched by the pattern. It seems that based on the [dist-zip](https://docs.gradle.org/current/userguide/application_plugin.html#sec:the_distribution) format should in most cases only generate a single Unix and a single Window script. The format is very flexible, so it's possible a user could customize and generate more scripts but this is going to be less common. Thus by default, we are only going to match when a single script is present.

If multiple scripts are matched, there will be messages emitted indicating what happened at the DEBUG log level. If the Paketo DistZip buildpack does not run (or does not emit its title) at build time, look at the debug logs from detection to see if it matched multiple scripts. A user can then set `$BP_APPLICATION_SCRIPT` to a more strict pattern (or the exact file name of their dist-zip archive).

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
