### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `gcr.io/paketo-buildpacks/dist-zip`
-The Paketo DistZip Buildpack is a Cloud Native Buildpack that contributes a Process Type for DistZip-style applications.
+The Paketo Buildpack for DistZip is a Cloud Native Buildpack that contributes a Process Type for DistZip-style applications.
 
 ## Behavior
 This buildpack will participate all the following conditions are met

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,7 +16,7 @@ api = "0.7"
 
 [buildpack]
   id       = "paketo-buildpacks/dist-zip"
-  name     = "Paketo DistZip Buildpack"
+  name     = "Paketo Buildpack for DistZip"
   version  = "{{.version}}"
   homepage = "https://github.com/paketo-buildpacks/dist-zip"
   description = "A Cloud Native Buildpack that contributes a Process Type for DistZip-style applications"


### PR DESCRIPTION
Renames 'Paketo DistZip Buildpack' to 'Paketo Buildpack for DistZip'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
