### PR TITLE
Fix #173: Add flag to make application path group-writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ When `$BP_LIVE_RELOAD_ENABLE` is true:
 * Contributes `reload` process type
 
 ## Configuration
-| Environment Variable      | Description                                                                                       |
-| ------------------------- | ------------------------------------------------------------------------------------------------- |
-| `$BP_APPLICATION_SCRIPT`  | Configures the application start script, using [Bash Pattern Matching][b]. Defaults to `*/bin/*`. |
-| `$BP_LIVE_RELOAD_ENABLED` | Enable live process reloading. Defaults to false.                                                 |
+| Environment Variable          | Description                                                                                                   |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------|
+| `$BP_APPLICATION_SCRIPT`      | Configures the application start script, using [Bash Pattern Matching][b]. Defaults to `*/bin/*`.             |
+| `$BP_LIVE_RELOAD_ENABLED`     | Enable live process reloading. Defaults to false.                                                             |
+| `$BP_APP_PATH_GROUP_WRITABLE` | Make the application path group-writable; convenient for apps that write files at runtime. Defaults to false. |
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -48,6 +48,12 @@ description = "enable live process reload in the image"
 default     = "false"
 build       = true
 
+[[metadata.configurations]]
+name        = "BP_APP_PATH_GROUP_WRITABLE"
+description = "make the application path group-writable"
+default     = "false"
+build       = true
+
 [metadata]
 pre-package   = "scripts/build.sh"
 include-files = [


### PR DESCRIPTION
* Introducing BP_APP_PATH_GROUP_WRITABLE, defaults to false

## Use Cases
```
> pack build -p ~/Downloads/apache-activemq-dist.zip dist --env BP_APP_PATH_GROUP_WRITABLE=true -e BP_APPLICATION_SCRIPT=apache-activemq-dist/bin/activemq -b paketo-buildpacks/syft \
-b paketo-buildpacks/bellsoft-liberica \
-b . \
 --builder paketobuildpacks/builder:base --verbose --clear-cache
[...]
Paketo Buildpack for DistZip {{.version}}
  https://github.com/paketo-buildpacks/dist-zip
  Build Configuration:
    $BP_APPLICATION_SCRIPT       apache-activemq-dist/bin/activemq  the application start script
    $BP_APP_PATH_GROUP_WRITABLE  true                               make the application path group-writable
    $BP_LIVE_RELOAD_ENABLED      false                              enable live process reload in the image
  Successfully marked applicationPath, /workspace, as group-writable
  Process types:
    dist-zip: /workspace/apache-activemq-dist/bin/activemq
    task:     /workspace/apache-activemq-dist/bin/activemq
    web:      /workspace/apache-activemq-dist/bin/activemq
[...]
> docker run -it --entrypoint=ls dist -al /workspace 
total 12
drwxr-xr-x  3 cnb  cnb  4096 Jan  1  1980 .
drwxr-xr-x  1 root root 4096 May  3 13:45 ..
drwxrwxr-x 10 cnb  cnb  4096 Jan  1  1980 apache-activemq-dist

```




## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
